### PR TITLE
Poprawienie drobnych błędów, zniana zmiennej prev_direcion z int na bool

### DIFF
--- a/Sumo_Kolo - Knr/Core/Src/main.c
+++ b/Sumo_Kolo - Knr/Core/Src/main.c
@@ -55,10 +55,10 @@ void enable_motor(int motor_id)
 {
 	switch(motor_id)
 	{
-	case 1:
+	case RIGTH_MOTOR:
 		HAL_GPIO_WritePin(EN_Motor_1_GPIO_Port, EN_Motor_1_Pin,SET);
 		break;
-	case 2:
+	case LEFT_MOTOR:
 		HAL_GPIO_WritePin(EN_Motor_2_GPIO_Port, EN_Motor_2_Pin,SET);
 		break;
 	}

--- a/Sumo_Kolo - Knr/Core/Src/main.c
+++ b/Sumo_Kolo - Knr/Core/Src/main.c
@@ -166,7 +166,7 @@ int main(void)
 	  if (HAL_GPIO_ReadPin(BLUE_BUTTON_GPIO_Port, BLUE_BUTTON_Pin) == GPIO_PIN_RESET&&HAL_GetTick()>(timer+5000))
 	  {
 
-		  	  int prev_direction=direction;
+		  	  bool prev_direction=direction;
 			  direction=change_direction(prev_direction,1);
 			  direction=change_direction(prev_direction,2);
 			  timer=HAL_GetTick();


### PR DESCRIPTION
Naprawienie błędu braku wykożystania w kilku miejscach motor_id jak LEFT_MOTOR i RIGTH_MOTOR.

zniana zmiennej prev_direcion z int na bool, ponieważ sama zmienna direction była bool bez sensu aby prev_direction było intem.